### PR TITLE
[Housekeeping] Bump Android Target SDK

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_16.0.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.1.0.app
 
       - name: Linting
         run: make clean-ios analyze-ios
@@ -45,7 +45,7 @@ jobs:
           cache: 'gradle'
 
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_16.0.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.1.0.app
 
       - name: Test
         run: make clean-ios test-ios report-ios
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_16.0.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.1.0.app
 
       - name: Build
         run: make clean-ios build-ios

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -10,11 +10,11 @@ plugins {
 
 android {
     namespace = "com.hellocuriosity.adventure.android"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         applicationId = "com.hellocuriosity.adventure.android"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }
@@ -70,9 +70,10 @@ android {
         htmlReport = true
         warningsAsErrors = true
         disable += mutableSetOf(
+            "AndroidGradlePluginVersion",
             "GoogleAppIndexingWarning",
             "GradleDependency",
-            "ObsoleteLintCustomCheck"
+            "ObsoleteLintCustomCheck",
         )
     }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -58,7 +58,7 @@ kotlin {
 
 android {
     namespace = "com.hellocuriosity.adventure"
-    compileSdk = 35
+    compileSdk = 36
     defaultConfig {
         minSdk = 24
     }


### PR DESCRIPTION
## Description
This bumps the Android target SDK to 36.

## Housekeeping
* Disable outdated AGP dependencies as linting errors.
* Make Xcode version an environment variable.

## Review checklist

- [x] PR is split into meaningful commits for the ease of reviewing
- [x] Tests have been written
- [ ] Screenshots added (where applicable)
- [x] Appropriate labels have been applied
